### PR TITLE
Upgrade gen_socket

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -45,7 +45,7 @@
   0},
  {<<"gen_socket">>,
   {git,"git://github.com/travelping/gen_socket.git",
-       {ref,"072a6306b88a2f8e754e180d87e958e7c88a22d5"}},
+       {ref,"195a42700ba15b7ddc26a49865abcdaa627eba33"}},
   1},
  {<<"goldrush">>,
   {git,"https://github.com/basho/goldrush.git",


### PR DESCRIPTION
*gen_socket* was modified in 'master' to be built in Alpine Linux.
Thus, rebar.lock needs to be updated to reflect the change.