### PR TITLE
Provide Dockerfile for Alpine Linux images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Build
     $ rebar3 compile
 
 Docker container images
-------------------------
+-----------------------
 
 This repository also creates a [Docker
 image](https://hub.docker.com/r/ergw/ergw-capwap-node/) which can be used as a
@@ -36,3 +36,11 @@ to `/config/ergw-capwap-node` containing the `sys.config` and `vm.args` erlang
 config. Alternatively, you may use a volume to provide the configuration in
 `/etc/erlang-capwap-node/erlang-capwap-node.config` or alter this file in
 a running container.
+
+Via docker/Dockerfile.alpine an experimental Docker file exists which builds
+a much smaller container image of CAPWAP AC … ~58Mb. It makes use of a feature
+in Docker called "multi stage" builds and needs at least Docker-17.05. Build
+the image like this:
+
+    $ docker build -f docker/Dockerfile.alpine -t ergw-capwap-node:alpine .
+

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,51 @@
+# -- build-environment --
+# see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+
+FROM alpine:3.7 AS build-env
+
+WORKDIR /build
+RUN     apk update && apk --no-cache upgrade && \
+        apk --no-cache add \
+            erlang \
+                erlang-asn1 erlang-compiler erlang-crypto erlang-dev \
+                erlang-diameter erlang-eunit erlang-hipe erlang-inets \
+                erlang-kernel erlang-parsetools erlang-public-key \
+                erlang-runtime-tools erlang-sasl erlang-ssl erlang-stdlib \
+                erlang-syntax-tools \
+            gcc \
+            git \
+            libc-dev libc-utils \
+            libgcc \
+            linux-headers \
+            make \
+            musl-dev musl-utils \
+            pcre2 \
+            pkgconf \
+            scanelf \
+            wget \
+            zlib
+
+RUN     wget -O /usr/local/bin/rebar3 https://s3.amazonaws.com/rebar3/rebar3 && \
+        chmod a+x /usr/local/bin/rebar3
+
+ADD     . /build
+RUN     rebar3 as prod,native get-deps && rebar3 as prod,native release
+
+# -- runtime image --
+
+FROM    alpine:3.7
+
+WORKDIR /
+RUN     apk update && \
+        apk --no-cache upgrade && \
+        apk --no-cache add ncurses-libs libcrypto1.0
+COPY    docker/docker-entrypoint.sh /
+COPY    config/ergw-capwap-node.config /etc/ergw-capwap-node/
+
+RUN     mkdir -p /var/lib/ergw/ && \
+        touch /var/lib/ergw/ergw.state
+
+COPY    --from=build-env /build/_build/prod+native/rel/ /opt/
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD     ["/opt/ergw-capwap-node/bin/ergw-capwap-node", "foreground"]


### PR DESCRIPTION
This commit provides a new Dockerfile which builds an CAPWAP AC image
based upon Alpine Linux. The resulting image is ~40Mb small. In
comparison, the Ubuntu based image is roughly 235Mb big.

Building the image requires Docker-17.05 due to the multi-stage builds
feature of Docker.